### PR TITLE
Fix badge splitting if user has no badges

### DIFF
--- a/irc/types.go
+++ b/irc/types.go
@@ -88,15 +88,15 @@ func NewChatSender(msg Message) ChatSender {
 		sender.UserID = id
 	}
 
-    if len(msg.Tags["badges"]) > 0 {
+	if len(msg.Tags["badges"]) > 0 {
 		badges := strings.Split(msg.Tags["badges"], ",")
 		if len(badges) > 0 {
 			for _, badge := range badges {
-			data := strings.Split(badge, "/")
-			    sender.Badges[data[0]] = data[1]
+				data := strings.Split(badge, "/")
+				sender.Badges[data[0]] = data[1]
 			}
-	    }
-    }
+		}
+	}
 
 	_, subBadge := sender.Badges["subscriber"]
 	sender.IsSubscriber = subBadge || msg.Tags["subscriber"] == "1"

--- a/irc/types.go
+++ b/irc/types.go
@@ -88,13 +88,15 @@ func NewChatSender(msg Message) ChatSender {
 		sender.UserID = id
 	}
 
-	badges := strings.Split(msg.Tags["badges"], ",")
-	if len(badges) > 0 {
-		for _, badge := range badges {
+    if len(msg.Tags["badges"]) > 0 {
+		badges := strings.Split(msg.Tags["badges"], ",")
+		if len(badges) > 0 {
+			for _, badge := range badges {
 			data := strings.Split(badge, "/")
-			sender.Badges[data[0]] = data[1]
-		}
-	}
+			    sender.Badges[data[0]] = data[1]
+			}
+	    }
+    }
 
 	_, subBadge := sender.Badges["subscriber"]
 	sender.IsSubscriber = subBadge || msg.Tags["subscriber"] == "1"


### PR DESCRIPTION
When an user didn't have a badge it would panic. Added a check to see if the user had a badge.