### PR TITLE
Fix: Update `Stream` struct to include display name and login name

### DIFF
--- a/api/helix/streams.go
+++ b/api/helix/streams.go
@@ -30,7 +30,8 @@ type StreamsData struct {
 type Stream struct {
 	ID           string   `json:"id"`
 	UserID       string   `json:"user_id"`
-	Login        string   `json:"user_name"`
+	UserName     string   `json:"user_name"`
+	UserLogin    string   `json:"user_login"`
 	GameID       string   `json:"game_id"`
 	Title        string   `json:"title"`
 	ThumbnailURL string   `json:"thumbnail_url"`


### PR DESCRIPTION
This is an issue because the `Login` value of `User` is the login name with `Login` of `Stream` is the display name which could differ