### PR TITLE
Fix deadlock when failing to leave an IRC channel.

### DIFF
--- a/irc/client.go
+++ b/irc/client.go
@@ -142,6 +142,7 @@ func (client *Client) Join(channels ...string) error {
 // Leave attempts to leave a channel
 func (client *Client) Leave(channels ...string) error {
 	client.mx.Lock()
+	defer client.mx.Unlock()
 	for _, shard := range client.shards {
 		for _, channel := range channels {
 			if _, ok := shard.GetChannel(channel); ok {
@@ -151,7 +152,6 @@ func (client *Client) Leave(channels ...string) error {
 			}
 		}
 	}
-	client.mx.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Hello, looks like there is a missing Unlock, when leaving an irc-channel failed.